### PR TITLE
Update Jenkins Plugins to Resolve Dependency Issues

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -21,12 +21,12 @@
 # [1] https://github.com/openshift/jenkins/blob/master/2/contrib/openshift/bundle-plugins.txt
 # [2] https://github.com/openshift/jenkins/blob/master/2/contrib/openshift/base-plugins.txt
 # [3] https://github.com/openshift/jenkins#plugin-installation-for-centos7-v410
-basic-branch-build-strategies:228.v68c089762a_db_
-generic-webhook-trigger:2.3.1
+basic-branch-build-strategies:190.v343a_ee70d920
+generic-webhook-trigger:2.3.0
 github-oauth:621.v33b_4394dda_4d
 kubernetes-credentials-provider:1.273.v15e69b_55ea_8e
 pipeline-github:2.8-159.09e4403bc62f
-slack:761.v2a_8770f0d169
+slack:760.vb_e6a_66db_2d43
 timestamper:1.28
 splunk-devops-extend:1.10.2
 splunk-devops:1.10.2


### PR DESCRIPTION
The update of three plugins seem to be having issues from the update list, the below plugin versions seem to run into dependency issues:

- basic-branch-build-strategies:228.v68c089762a_db_
- generic-webhook-trigger:2.3.1
- slack:761.v2a_8770f0d169

The final updated list of plugins would be:

- basic-branch-build-strategies:190.v343a_ee70d920
- generic-webhook-trigger:2.3.0
- slack:760.vb_e6a_66db_2d43

Each plugin version was tested and verified to work without introducing any dependency conflicts.