### PR TITLE
jenkins/plugins: update to latest versions

### DIFF
--- a/jenkins/controller/plugins.txt
+++ b/jenkins/controller/plugins.txt
@@ -21,17 +21,18 @@
 # [1] https://github.com/openshift/jenkins/blob/master/2/contrib/openshift/bundle-plugins.txt
 # [2] https://github.com/openshift/jenkins/blob/master/2/contrib/openshift/base-plugins.txt
 # [3] https://github.com/openshift/jenkins#plugin-installation-for-centos7-v410
-basic-branch-build-strategies:81.v05e333931c7d
-generic-webhook-trigger:2.0.1
-github-oauth:597.ve0c3480fcb_d0
-kubernetes-credentials-provider:1.262.v2670ef7ea_0c5
-pipeline-github:2.8-159.09e4403bc62f
-slack:684.v833089650554
-timestamper:1.27
-splunk-devops-extend:1.10.2
-splunk-devops:1.10.2
-antisamy-markup-formatter:162.v0e6ec0fcfcf6
+basic-branch-build-strategies:228.v68c089762a_db_
+generic-webhook-trigger:2.3.1
+github-oauth:621.v33b_4394dda_4d
+kubernetes-credentials-provider:1.281.v331e3f5a_05a_9
+pipeline-github:2.8-162.382498405fdc
+slack:761.v2a_8770f0d169
+timestamper:1.30
+splunk-devops-extend:1.11.0
+splunk-devops:1.11.0
+antisamy-markup-formatter:173.v680e3a_b_69ff3
 jms-messaging:1.1.28
+pipeline-graph-view:584.v32e797f976a_2
 
 # The below list are plugins that are also in base-plugins.txt but for
 # some reason or other we need to temporarily freeze or fast-track.


### PR DESCRIPTION
Job URL: https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/bump-jenkins-plugins/5/

Job definition: https://github.com/coreos/fedora-coreos-pipeline/blob/main/jobs/bump-jenkins-plugins.Jenkinsfile